### PR TITLE
feat(readProxySpConfig): add sync facade

### DIFF
--- a/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.spec.ts
@@ -60,4 +60,11 @@ describe('ReadSpProxyConfigFacade', () => {
     expect(handleSpy).toHaveBeenCalledTimes(1)
     expect(handleSpy).toHaveBeenCalledWith(expectedDto)
   })
+  it('should throw if controller throws', async () => {
+    const { sut, controllerStub } = makeSut()
+    jest.spyOn(controllerStub, 'handle').mockImplementationOnce(() => {
+      throw new Error()
+    })
+    await expect(sut.do()).rejects.toThrow()
+  })
 })

--- a/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.spec.ts
@@ -8,6 +8,7 @@ import { IController } from '@sp-proxy/interface-adapters/protocols/IController'
 import { IRequest } from '@sp-proxy/interface-adapters/protocols/IRequest'
 import { EventEmitter } from 'stream'
 import * as crypto from 'crypto'
+import { IReadSpProxyConfigRequest } from '@sp-proxy/interface-adapters/delivery/dtos/IReadSpProxyConfigRequest'
 jest.mock('crypto')
 
 const makeController = (): IController => {
@@ -47,5 +48,16 @@ describe('ReadSpProxyConfigFacade', () => {
       'mocked request id',
       expect.any(Function)
     )
+  })
+  it('should call controller handle with request dto', async () => {
+    const { sut, controllerStub } = makeSut()
+    const handleSpy = jest.spyOn(controllerStub, 'handle')
+    const expectedDto: IRequest<IReadSpProxyConfigRequest> = {
+      id: 'mocked request id',
+      body: null
+    }
+    await sut.do()
+    expect(handleSpy).toHaveBeenCalledTimes(1)
+    expect(handleSpy).toHaveBeenCalledWith(expectedDto)
   })
 })

--- a/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.spec.ts
@@ -29,6 +29,10 @@ interface SutTypes {
 const makeSut = (): SutTypes => {
   const controllerStub = makeController()
   const eventBusStub = new EventEmitter()
+  // mock controller to call eventBus (in the full impl event is triggered by presenter)
+  jest.spyOn(controllerStub as any, 'handle').mockImplementation(() => {
+    eventBusStub.emit('mocked request id', { body: 'stubbed request dto' })
+  })
   const sut = new ReadSpProxyConfigFacade(eventBusStub, controllerStub)
   return { sut, controllerStub, eventBusStub }
 }
@@ -66,5 +70,9 @@ describe('ReadSpProxyConfigFacade', () => {
       throw new Error()
     })
     await expect(sut.do()).rejects.toThrow()
+  })
+  it('should return response body listened', async () => {
+    const { sut } = makeSut()
+    expect(await sut.do()).toEqual('stubbed request dto')
   })
 })

--- a/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.test.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.test.ts
@@ -1,0 +1,92 @@
+import { SpProxyConfig } from '@sp-proxy/entities/SpProxyConfig'
+import { ReadSpProxyConfigFacade } from '@sp-proxy/interface-adapters/api/ReadSpProxyConfigFacade'
+import { FileReadProxyConfig } from '@sp-proxy/interface-adapters/data/FileReadProxyConfig'
+import { ReadSpProxyConfigControllerMapper } from '@sp-proxy/interface-adapters/delivery/mappers/ReadSpProxyConfigControllerMapper'
+import { ReadSpProxyConfigPresenterMapper } from '@sp-proxy/interface-adapters/delivery/mappers/ReadSpProxyConfigPresenterMapper'
+import { ReadSpProxyConfigController } from '@sp-proxy/interface-adapters/delivery/ReadSpProxyConfigController'
+import { ReadSpProxyConfigPresenter } from '@sp-proxy/interface-adapters/delivery/ReadSpProxyConfigPresenter'
+import { KeyCertLoader } from '@sp-proxy/interface-adapters/external-services/KeyCertLoader'
+import { ReadSpProxyConfigFormatter } from '@sp-proxy/interface-adapters/utils/formatters/ReadSpProxyConfigFormatter'
+import { ReadSpProxyConfigTransformer } from '@sp-proxy/interface-adapters/utils/transformers/ReadSpProxyConfigTransformer'
+import { ReadSpProxyConfigInteractor } from '@sp-proxy/use-cases/ReadSpProxyConfigInteractor'
+import { EventEmitter } from 'stream'
+import * as configRepo from '@sp-proxy/interface-adapters/data/FileReadProxyConfig'
+import { SpProxyConfigProps } from '@sp-proxy/entities/protocols/SpProxyConfigProps'
+import cfg from '@sp-proxy/interface-adapters/config/env'
+import { readFileSync } from 'fs'
+import { IReadSpProxyConfigResponse } from '@sp-proxy/interface-adapters/delivery/dtos/IReadSpProxyConfigResponse'
+jest.mock('@sp-proxy/interface-adapters/data/FileReadProxyConfig')
+
+const loadedCert = readFileSync(process.cwd() + '/packages/testdata/cert.pem')
+  .toString()
+  .replace(/(\r\n|\n|\r)/gm, '')
+  .replace('-----BEGIN CERTIFICATE-----', '')
+  .replace('-----END CERTIFICATE-----', '')
+const loadedPvk = readFileSync(process.cwd() + '/packages/testdata/key.pem')
+  .toString()
+  .replace(/(\r\n|\n|\r)/gm, '')
+  .replace('-----BEGIN ENCRYPTED PRIVATE KEY-----', '')
+  .replace('-----END ENCRYPTED PRIVATE KEY-----', '')
+
+const eventBus = new EventEmitter()
+const presenterMapper = new ReadSpProxyConfigPresenterMapper()
+const presenter = new ReadSpProxyConfigPresenter(presenterMapper, eventBus)
+
+const gateway = new FileReadProxyConfig()
+const loader = new KeyCertLoader()
+const formatter = new ReadSpProxyConfigFormatter()
+const transformer = new ReadSpProxyConfigTransformer(loader, formatter)
+const interactor = new ReadSpProxyConfigInteractor(
+  gateway,
+  transformer,
+  presenter
+)
+
+const controllerMapper = new ReadSpProxyConfigControllerMapper()
+const controller = new ReadSpProxyConfigController(controllerMapper, interactor)
+
+const sut = new ReadSpProxyConfigFacade(eventBus, controller)
+
+describe('ReadSpProxyConfigFacade - integration', () => {
+  const mockedProps: SpProxyConfigProps = {
+    host: 'myhost.com',
+    requestedIdentifierFormat: 'my:name:identifier:requested',
+    authnContextIdentifierFormat: 'my:authn:name:identifier:format',
+    skipRequestCompression: true,
+    decryption: {
+      publicCertPath: process.cwd() + '/packages/testdata/cert.pem',
+      privateKeyPath: process.cwd() + '/packages/testdata/key.pem'
+    },
+    signing: {
+      publicCertPath: process.cwd() + '/packages/testdata/cert.pem',
+      privateKeyPath: process.cwd() + '/packages/testdata/key.pem'
+    }
+  }
+  const mockedConfig: SpProxyConfig = new SpProxyConfig(mockedProps)
+
+  beforeAll(async () => {
+    jest
+      .spyOn(configRepo.FileReadProxyConfig.prototype, 'read')
+      .mockResolvedValueOnce(mockedConfig)
+
+    cfg.database.file.proxyConfigPath =
+      process.cwd() + '/packages/testdata/sp-proxy-config-test.json'
+  })
+  it('should return expected configuration props', async () => {
+    const expected: IReadSpProxyConfigResponse = {
+      host: mockedProps.host,
+      requestedIdentifierFormat: mockedProps.requestedIdentifierFormat,
+      authnContextIdentifierFormat: mockedProps.authnContextIdentifierFormat,
+      skipRequestCompression: mockedProps.skipRequestCompression,
+      decryption: {
+        privateKey: loadedPvk,
+        cert: loadedCert
+      },
+      signing: {
+        privateKey: loadedPvk,
+        cert: loadedCert
+      }
+    }
+    expect(await sut.do()).toStrictEqual(expected)
+  })
+})

--- a/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.ts
@@ -1,6 +1,7 @@
 import { IReadSpProxyConfigRequest } from '@sp-proxy/interface-adapters/delivery/dtos/IReadSpProxyConfigRequest'
 import { IReadSpProxyConfigResponse } from '@sp-proxy/interface-adapters/delivery/dtos/IReadSpProxyConfigResponse'
 import { IController } from '@sp-proxy/interface-adapters/protocols/IController'
+import { IResponse } from '@sp-proxy/interface-adapters/protocols/IResponse'
 import { ISyncFacade } from '@sp-proxy/interface-adapters/protocols/ISyncFacade'
 import { randomUUID } from 'crypto'
 import { EventEmitter } from 'stream'
@@ -15,11 +16,17 @@ export class ReadSpProxyConfigFacade
 
   async do(): Promise<IReadSpProxyConfigResponse> {
     const requestId = randomUUID()
-    this.eventBus.once(requestId, () => {})
+    const result: IReadSpProxyConfigResponse[] = []
+    this.eventBus.once(
+      requestId,
+      (responseDto: IResponse<IReadSpProxyConfigResponse>) => {
+        result.push(responseDto.body)
+      }
+    )
     await this.controller.handle({
       id: requestId,
       body: null
     })
-    return 'not impl' as any
+    return result[0]
   }
 }

--- a/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.ts
@@ -1,0 +1,21 @@
+import { IReadSpProxyConfigRequest } from '@sp-proxy/interface-adapters/delivery/dtos/IReadSpProxyConfigRequest'
+import { IReadSpProxyConfigResponse } from '@sp-proxy/interface-adapters/delivery/dtos/IReadSpProxyConfigResponse'
+import { IController } from '@sp-proxy/interface-adapters/protocols/IController'
+import { ISyncFacade } from '@sp-proxy/interface-adapters/protocols/ISyncFacade'
+import { randomUUID } from 'crypto'
+import { EventEmitter } from 'stream'
+
+export class ReadSpProxyConfigFacade
+  implements ISyncFacade<IReadSpProxyConfigRequest, IReadSpProxyConfigResponse>
+{
+  constructor(
+    private readonly eventBus: EventEmitter,
+    private readonly controller: IController
+  ) {}
+
+  async do(): Promise<IReadSpProxyConfigResponse> {
+    const requestId = randomUUID()
+    this.eventBus.once(requestId, () => {})
+    return 'not impl' as any
+  }
+}

--- a/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/ReadSpProxyConfigFacade.ts
@@ -16,6 +16,10 @@ export class ReadSpProxyConfigFacade
   async do(): Promise<IReadSpProxyConfigResponse> {
     const requestId = randomUUID()
     this.eventBus.once(requestId, () => {})
+    await this.controller.handle({
+      id: requestId,
+      body: null
+    })
     return 'not impl' as any
   }
 }

--- a/packages/sp-proxy/src/interface-adapters/protocols/ISyncFacade.ts
+++ b/packages/sp-proxy/src/interface-adapters/protocols/ISyncFacade.ts
@@ -1,0 +1,3 @@
+export interface ISyncFacade<ReqProps, ResProps> {
+  do: (request: ReqProps) => Promise<ResProps>
+}

--- a/packages/sp-proxy/src/use-cases/ReadSpProxyConfigInteractor.spec.ts
+++ b/packages/sp-proxy/src/use-cases/ReadSpProxyConfigInteractor.spec.ts
@@ -36,30 +36,24 @@ const makeGateway = (): IReadProxyConfigGateway => {
 
 const makeTransformer = (): ITransformer<
   SpProxyConfig,
-  IResponseModel<ReadSpProxyConfigResponseUseCaseParams>
+  ReadSpProxyConfigResponseUseCaseParams
 > => {
   class TransformerStub
     implements
-      ITransformer<
-        SpProxyConfig,
-        IResponseModel<ReadSpProxyConfigResponseUseCaseParams>
-      >
+      ITransformer<SpProxyConfig, ReadSpProxyConfigResponseUseCaseParams>
   {
     async transform(
       from: SpProxyConfig
-    ): Promise<IResponseModel<ReadSpProxyConfigResponseUseCaseParams>> {
+    ): Promise<ReadSpProxyConfigResponseUseCaseParams> {
       return {
-        requestId: 'request id transform stub',
-        response: {
-          host: 'transform stubbed host',
-          requestedIdentifierFormat: 'transform stubbed identifier format',
-          authnContextIdentifierFormat:
-            'transform stubbed authn context identifier format',
-          skipRequestCompression: true,
-          decryption: {
-            privateKey: 'valid stunbbed pvk string',
-            cert: 'valid stubbed cert string'
-          }
+        host: 'transform stubbed host',
+        requestedIdentifierFormat: 'transform stubbed identifier format',
+        authnContextIdentifierFormat:
+          'transform stubbed authn context identifier format',
+        skipRequestCompression: true,
+        decryption: {
+          privateKey: 'valid stunbbed pvk string',
+          cert: 'valid stubbed cert string'
         }
       }
     }
@@ -87,7 +81,7 @@ interface SutTypes {
   gatewayStub: IReadProxyConfigGateway
   transformerStub: ITransformer<
     SpProxyConfig,
-    IResponseModel<ReadSpProxyConfigResponseUseCaseParams>
+    ReadSpProxyConfigResponseUseCaseParams
   >
   presenterStub: OutputBoundary<
     IResponseModel<ReadSpProxyConfigResponseUseCaseParams>
@@ -154,10 +148,15 @@ describe('ReadSpProxyConfigInteractor', () => {
     const presentSpy = jest.spyOn(presenterStub, 'present')
     jest
       .spyOn(transformerStub, 'transform')
-      .mockResolvedValueOnce('valid response model' as any)
+      .mockResolvedValueOnce('valid response body' as any)
     await sut.execute(fakeRequestModel)
     expect(presentSpy).toHaveBeenCalledTimes(1)
-    expect(presentSpy).toHaveBeenCalledWith('valid response model')
+    const expectedResponseModel: IResponseModel<ReadSpProxyConfigResponseUseCaseParams> =
+      {
+        requestId: fakeRequestModel.requestId,
+        response: 'valid response body' as any
+      }
+    expect(presentSpy).toHaveBeenCalledWith(expectedResponseModel)
   })
   it('should throw if presenter throws', async () => {
     const { sut, presenterStub } = makeSut()

--- a/packages/sp-proxy/src/use-cases/ReadSpProxyConfigInteractor.ts
+++ b/packages/sp-proxy/src/use-cases/ReadSpProxyConfigInteractor.ts
@@ -15,7 +15,7 @@ export class ReadSpProxyConfigInteractor
     private readonly gateway: IReadProxyConfigGateway,
     private readonly transformer: ITransformer<
       SpProxyConfig,
-      IResponseModel<ReadSpProxyConfigResponseUseCaseParams>
+      ReadSpProxyConfigResponseUseCaseParams
     >,
     private readonly outputBoundary: OutputBoundary<
       IResponseModel<ReadSpProxyConfigResponseUseCaseParams>
@@ -26,7 +26,10 @@ export class ReadSpProxyConfigInteractor
     request: IRequestModel<ReadSpProxyConfigRequestUseCaseParams>
   ): Promise<void> {
     const spProxyConfig = await this.gateway.read()
-    const responseModel = await this.transformer.transform(spProxyConfig)
-    await this.outputBoundary.present(responseModel)
+    const responseModelProps = await this.transformer.transform(spProxyConfig)
+    await this.outputBoundary.present({
+      requestId: request.requestId,
+      response: responseModelProps
+    })
   }
 }


### PR DESCRIPTION
Ref issue: #80

Config will be fetched using façade's `do()` method.

Ps: This is the first façade using do (command pattern), other façades should and will be refactored to follow same structure (implement `ISyncFacade`) so we can easily use decorators and IoC.