### PR TITLE
fix(UmaAuthenticator): use correct methods to request ticket #

### DIFF
--- a/packages/sp-proxy/src/frameworks-drivers/main/routes/addTrFromMetadataRouter.test.ts
+++ b/packages/sp-proxy/src/frameworks-drivers/main/routes/addTrFromMetadataRouter.test.ts
@@ -2,13 +2,12 @@ import serverConfig from '@sp-proxy/frameworks-drivers/main/config/env'
 import { mockValidXmlDataEndpoint } from '@sp-proxy/frameworks-drivers/main/mocks/externalMetadataUrl.mock'
 import { mockSpProxyConfig } from '@sp-proxy/frameworks-drivers/main/mocks/mockSpProxyConfig.mock'
 import routes from '@sp-proxy/frameworks-drivers/main/routes'
-import { mockUmaEndpoint } from '@sp-proxy/interface-adapters/data/mocks/mockUmaEndpoint.mock'
+import { mockPostUmaEndpoint } from '@sp-proxy/interface-adapters/data/mocks/mockUmaEndpoint.mock'
 import { AddTrFromMetadataController } from '@sp-proxy/interface-adapters/delivery/AddTrFromMetadataController'
 import { InvalidRequestError } from '@sp-proxy/interface-adapters/delivery/errors/InvalidRequestError'
 import express from 'express'
 import nock from 'nock'
 import request from 'supertest'
-import { mockAddTrEndpoint } from '../mocks/mockAddTrEndpoint'
 
 jest.mock('@sp-proxy/interface-adapters/data/FileReadProxyConfig')
 
@@ -85,8 +84,7 @@ describe('addTrFromMetadataRouter', () => {
   })
   it('should return 201 if success', async () => {
     mockValidXmlDataEndpoint()
-    mockUmaEndpoint('trusted-idp', {})
-    mockAddTrEndpoint()
+    mockPostUmaEndpoint('trusted-idp', {})
     await request(app)
       .post(endpoint)
       .set('authorization', validCredentials)
@@ -97,9 +95,8 @@ describe('addTrFromMetadataRouter', () => {
       .expect(201)
   })
   it('should return success message', async () => {
-    mockAddTrEndpoint()
     mockValidXmlDataEndpoint()
-    mockUmaEndpoint('trusted-idp', {})
+    mockPostUmaEndpoint('trusted-idp', {})
     await request(app)
       .post(endpoint)
       .set('authorization', validCredentials)
@@ -147,9 +144,8 @@ describe('addTrFromMetadataRouter', () => {
       .expect(401)
   })
   it('should return json content type', async () => {
-    mockAddTrEndpoint()
     mockValidXmlDataEndpoint()
-    mockUmaEndpoint('trusted-idp', {})
+    mockPostUmaEndpoint('trusted-idp', {})
     await request(app)
       .post(endpoint)
       .set('authorization', validCredentials)
@@ -158,5 +154,17 @@ describe('addTrFromMetadataRouter', () => {
         url: 'https://remoteIdp.com/metadata'
       })
       .expect('Content-Type', /json/)
+  })
+  it('should return 201', async () => {
+    mockValidXmlDataEndpoint()
+    mockPostUmaEndpoint('trusted-idp', {})
+    await request(app)
+      .post(endpoint)
+      .set('authorization', validCredentials)
+      .send({
+        name: 'valid name integration',
+        url: 'https://remoteIdp.com/metadata'
+      })
+      .expect(201)
   })
 })

--- a/packages/sp-proxy/src/frameworks-drivers/main/routes/authenticateCallbackRouter.test.ts
+++ b/packages/sp-proxy/src/frameworks-drivers/main/routes/authenticateCallbackRouter.test.ts
@@ -3,7 +3,10 @@ import serverConfig from '@sp-proxy/frameworks-drivers/main/config/env'
 import * as generator from '@sp-proxy/frameworks-drivers/main/helpers/generatePostProfileForm'
 import { mockAuthXmlEndpoint } from '@sp-proxy/frameworks-drivers/main/mocks/externalMetadataUrl.mock'
 import routes from '@sp-proxy/frameworks-drivers/main/routes'
-import { mockUmaEndpoint } from '@sp-proxy/interface-adapters/data/mocks/mockUmaEndpoint.mock'
+import {
+  mockGetUmaEndpoint,
+  mockPostUmaEndpoint
+} from '@sp-proxy/interface-adapters/data/mocks/mockUmaEndpoint.mock'
 import { TrustRelationDataModel } from '@sp-proxy/interface-adapters/data/models/TrustRelationDataModel'
 import express from 'express'
 import { readFileSync } from 'fs'
@@ -135,7 +138,7 @@ describe('authenticateCallbackRouter', () => {
   beforeEach(async () => {
     const mockedResponseData: TrustRelationDataModel = {
       remoteIdp: {
-        name: '"any name',
+        name: 'any name',
         host: 'samltest.id',
         supportedSingleSignOnServices: [
           { binding: 'valid binding', location: 'valid location' }
@@ -150,8 +153,8 @@ describe('authenticateCallbackRouter', () => {
         location: 'https://samltest.id/any-path'
       }
     }
-    mockUmaEndpoint('trusted-idps/samltest.id', mockedResponseData)
-    mockUmaEndpoint('trusted-idp', {})
+    mockGetUmaEndpoint('trusted-idp/samltest.id', mockedResponseData)
+    mockPostUmaEndpoint('trusted-idp', {})
     mockAddTrEndpoint()
     await createTrustRelationMock()
   })

--- a/packages/sp-proxy/src/frameworks-drivers/main/routes/authenticateRouter.test.ts
+++ b/packages/sp-proxy/src/frameworks-drivers/main/routes/authenticateRouter.test.ts
@@ -4,7 +4,7 @@
 // should return 302 redirect or POST form
 import { mockSpProxyConfig } from '@sp-proxy/frameworks-drivers/main/mocks/mockSpProxyConfig.mock'
 import routes from '@sp-proxy/frameworks-drivers/main/routes'
-import { mockUmaEndpoint } from '@sp-proxy/interface-adapters/data/mocks/mockUmaEndpoint.mock'
+import { mockGetUmaEndpoint } from '@sp-proxy/interface-adapters/data/mocks/mockUmaEndpoint.mock'
 import { TrustRelationDataModel } from '@sp-proxy/interface-adapters/data/models/TrustRelationDataModel'
 import express from 'express'
 import nock from 'nock'
@@ -18,7 +18,7 @@ describe('authenticateRouter', () => {
     mockSpProxyConfig()
 
     // setup mock for returning valid host from getTrByHost endpoint
-    // trusted-idps/{host}
+    // trusted-idp/{host}
 
     const responseData: TrustRelationDataModel = {
       remoteIdp: {
@@ -54,8 +54,8 @@ describe('authenticateRouter', () => {
         location: 'https://pocidp.techno24x7.com/idp/profile/SAML2/POST/SSO'
       }
     }
-    const endpoint = `trusted-idps/${responseData.remoteIdp.host}`
-    mockUmaEndpoint(endpoint, responseData)
+    const endpoint = `trusted-idp/${responseData.remoteIdp.host}`
+    mockGetUmaEndpoint(endpoint, responseData)
     app.use(routes)
   })
   afterAll(async () => {

--- a/packages/sp-proxy/src/interface-adapters/api/AddTrFromMetadataFacade.test.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/AddTrFromMetadataFacade.test.ts
@@ -17,20 +17,13 @@ import { TokenRequestFactory } from '../data/helpers/TokenRequestFactory'
 import { UmaAuthenticator } from '../data/helpers/UmaAuthenticator'
 import { UmaHeaderParser } from '../data/helpers/UmaHeaderParser'
 import { AddTrustRelationOxTrustMapper } from '../data/mappers/AddTrustRelationOxTrustMapper'
-import { mockUmaEndpoint } from '../data/mocks/mockUmaEndpoint.mock'
+import { mockPostUmaEndpoint } from '../data/mocks/mockUmaEndpoint.mock'
 import { OxTrustAddTrustRelation } from '../data/OxTrustAddTrustRelation'
-
-const mockAddTrEndpoint = (): void => {
-  nock(`https://${config.oxTrustApi.host}`)
-    .post(`/${config.oxTrustApi.completePath}/trusted-idp`)
-    .reply(201, 'created')
-}
 
 describe('AddTrFromMetadataFacade - integration', () => {
   beforeAll(async () => {
-    mockAddTrEndpoint()
     mockXmlEndpoints()
-    mockUmaEndpoint('trusted-idp', {})
+    mockPostUmaEndpoint('trusted-idp', {})
   })
   afterAll(async () => {
     nock.cleanAll()
@@ -55,7 +48,6 @@ describe('AddTrFromMetadataFacade - integration', () => {
       dataMapper,
       umaAuthenticator
     )
-    // const addTrGateway = new MongoAddTrustRelation(trustRelationsCollection)
     const interactor = new AddTrFromMetadataInteractor(
       externalDataGateway,
       remoteIdpFromExtDataFactory,

--- a/packages/sp-proxy/src/interface-adapters/api/GetTrByHostFacade.test.ts
+++ b/packages/sp-proxy/src/interface-adapters/api/GetTrByHostFacade.test.ts
@@ -4,11 +4,11 @@ import { InvalidRequestError } from '@sp-proxy/interface-adapters/delivery/error
 import nock from 'nock'
 import { EventEmitter } from 'stream'
 import { mockTokenEndpoint } from '../data/mocks/mockTokenEndpoint.mock'
-import { mockUmaEndpoint } from '../data/mocks/mockUmaEndpoint.mock'
+import { mockGetUmaEndpoint } from '../data/mocks/mockUmaEndpoint.mock'
 import { TrustRelationDataModel } from '../data/models/TrustRelationDataModel'
 import { IGetTrByHostResponse } from '../delivery/dtos/IGetTrByHostResponse'
 
-const trustedIdpsEndpoint = 'trusted-idps/valid.host.com'
+const trustedIdpsEndpoint = 'trusted-idp/valid.host.com'
 
 const mockedResponseData: TrustRelationDataModel = {
   remoteIdp: {
@@ -29,7 +29,7 @@ const mockedResponseData: TrustRelationDataModel = {
 describe('GetTrByHostFacade - integration', () => {
   beforeAll(async () => {
     mockTokenEndpoint()
-    mockUmaEndpoint(trustedIdpsEndpoint, mockedResponseData)
+    mockGetUmaEndpoint(trustedIdpsEndpoint, mockedResponseData)
   })
   afterAll(async () => {
     nock.cleanAll()

--- a/packages/sp-proxy/src/interface-adapters/data/OxTrustAddTrustRelation.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/OxTrustAddTrustRelation.ts
@@ -25,7 +25,7 @@ export class OxTrustAddTrustRelation implements IAddTrGateway {
     const trustRelationDataModel = await this.addTrustRelationOxTrustMapper.map(
       trustRelation
     )
-    const token = await this.authenticator.authenticate(this.postUrl)
+    const token = await this.authenticator.authenticate(this.postUrl, 'POST')
     const config: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${token}`

--- a/packages/sp-proxy/src/interface-adapters/data/OxTrustAddTrustRelation.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/OxTrustAddTrustRelation.ts
@@ -1,6 +1,7 @@
 import { TrustRelation } from '@sp-proxy/entities/TrustRelation'
 import { IAddTrGateway } from '@sp-proxy/use-cases/ports/IAddTrGateway'
 import axios, { AxiosRequestConfig } from 'axios'
+import { Agent } from 'https'
 import { IDataMapper } from '../protocols/IDataMapper'
 import { TrustRelationDataModel } from './models/TrustRelationDataModel'
 import { IOxTrustApiSettings } from './protocols/IOxTrustApiSettings'
@@ -29,7 +30,8 @@ export class OxTrustAddTrustRelation implements IAddTrGateway {
     const config: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${token}`
-      }
+      },
+      httpsAgent: new Agent({ rejectUnauthorized: false })
     }
     const response = await axios.post(
       this.postUrl,

--- a/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.spec.ts
@@ -9,6 +9,7 @@
 import { TrustRelation } from '@sp-proxy/entities/TrustRelation'
 import { IGetTrByHostGateway } from '@sp-proxy/use-cases/ports/IGetTrByHostGateway'
 import axios, { AxiosRequestConfig } from 'axios'
+import https from 'https'
 import { IDataMapper } from '../protocols/IDataMapper'
 import { TrustRelationDataModel } from './models/TrustRelationDataModel'
 import { OxTrustGetTrByHost } from './OxTrustGetTrByHost'
@@ -135,12 +136,28 @@ describe('OxTrustGetTrByHost', () => {
         Authorization: 'Bearer validBearerToken'
       }
     }
-    expect(getSpy).toHaveBeenCalledWith(expect.anything(), expectedConfig)
+    expect(getSpy.mock.calls[0][1]?.headers).toMatchObject(
+      expectedConfig.headers
+    )
   })
   it('should call authenticator once', async () => {
     const { sut, umaAuthenticatorStub } = makeSut()
     const authenticateSpy = jest.spyOn(umaAuthenticatorStub, 'authenticate')
     await sut.findByHost('valid host')
     expect(authenticateSpy).toHaveBeenCalled()
+  })
+  it('should call https Agent once with correct params', async () => {
+    const agentSpy = jest.spyOn(https, 'Agent')
+    const { sut } = makeSut()
+    await sut.findByHost('valid host')
+    expect(agentSpy).toHaveBeenCalledWith({ rejectUnauthorized: false })
+  })
+  it('shoulld call get with https agent', async () => {
+    const getSpy = jest.spyOn(axios, 'get')
+    const { sut } = makeSut()
+    await sut.findByHost('valid host')
+    expect(getSpy.mock.calls[0][1]?.httpsAgent.options).toMatchObject({
+      rejectUnauthorized: false
+    })
   })
 })

--- a/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.spec.ts
@@ -85,7 +85,7 @@ describe('OxTrustGetTrByHost', () => {
       .spyOn(axios, 'get')
       .mockResolvedValueOnce('any resolved response')
     const { oxTrustApiSettingsStub, sut } = makeSut()
-    const expectedUrlParam = `https://${oxTrustApiSettingsStub.host}/${oxTrustApiSettingsStub.completePath}/trusted-idps/valid-host`
+    const expectedUrlParam = `https://${oxTrustApiSettingsStub.host}/${oxTrustApiSettingsStub.completePath}/trusted-idp/valid-host`
     await sut.findByHost('valid-host')
     expect(getSpy).toHaveBeenCalledWith(expectedUrlParam, expect.anything())
   })

--- a/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.ts
@@ -1,6 +1,7 @@
 import { TrustRelation } from '@sp-proxy/entities/TrustRelation'
 import { IGetTrByHostGateway } from '@sp-proxy/use-cases/ports/IGetTrByHostGateway'
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
+import { Agent } from 'https'
 import { IDataMapper } from '../protocols/IDataMapper'
 import { TrustRelationDataModel } from './models/TrustRelationDataModel'
 import { IOxTrustApiSettings } from './protocols/IOxTrustApiSettings'
@@ -20,12 +21,14 @@ export class OxTrustGetTrByHost implements IGetTrByHostGateway {
   }
 
   async findByHost(host: string): Promise<TrustRelation> {
+    const httpsAgent = new Agent({ rejectUnauthorized: false })
     const urlWithHost = `${this.getUrl}/${host}`
     const token = await this.authenticator.authenticate(urlWithHost, 'GET')
     const config: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${token}`
-      }
+      },
+      httpsAgent
     }
     const response: AxiosResponse<TrustRelationDataModel> = await axios.get(
       urlWithHost,

--- a/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.ts
@@ -21,14 +21,13 @@ export class OxTrustGetTrByHost implements IGetTrByHostGateway {
   }
 
   async findByHost(host: string): Promise<TrustRelation> {
-    const httpsAgent = new Agent({ rejectUnauthorized: false })
     const urlWithHost = `${this.getUrl}/${host}`
     const token = await this.authenticator.authenticate(urlWithHost, 'GET')
     const config: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${token}`
       },
-      httpsAgent
+      httpsAgent: new Agent({ rejectUnauthorized: false })
     }
     const response: AxiosResponse<TrustRelationDataModel> = await axios.get(
       urlWithHost,

--- a/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/OxTrustGetTrByHost.ts
@@ -16,12 +16,12 @@ export class OxTrustGetTrByHost implements IGetTrByHostGateway {
     private readonly oxTrustApiSettings: IOxTrustApiSettings,
     private readonly authenticator: IUmaAuthenticator
   ) {
-    this.getUrl = `https://${oxTrustApiSettings.host}/${oxTrustApiSettings.completePath}/trusted-idps`
+    this.getUrl = `https://${oxTrustApiSettings.host}/${oxTrustApiSettings.completePath}/trusted-idp`
   }
 
   async findByHost(host: string): Promise<TrustRelation> {
     const urlWithHost = `${this.getUrl}/${host}`
-    const token = await this.authenticator.authenticate(urlWithHost)
+    const token = await this.authenticator.authenticate(urlWithHost, 'GET')
     const config: AxiosRequestConfig = {
       headers: {
         Authorization: `Bearer ${token}`

--- a/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.spec.ts
@@ -131,20 +131,22 @@ const validPostResponse: AxiosResponse = {
 }
 
 // mock default stub answer for axios.get and post to token endpoint
-jest.spyOn(axios, 'get').mockResolvedValue(valid401Response)
+jest.spyOn(axios, 'request').mockResolvedValue(valid401Response)
 jest.spyOn(axios, 'post').mockResolvedValue(validPostResponse)
 jest.spyOn(fs, 'readFileSync').mockReturnValue('pvk loaded from file')
 describe('UmaAuthenticator', () => {
   it('should request a valid endpoint', async () => {
-    const getSpy = jest
-      .spyOn(axios, 'get')
+    const requestSpy = jest
+      .spyOn(axios, 'request')
       .mockResolvedValueOnce(valid401Response)
     const { sut } = makeSut()
     await sut.authenticate('valid endpoint')
-    expect(getSpy).toHaveBeenCalledWith('valid endpoint', expect.anything())
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'valid endpoint' })
+    )
   })
   it('should throw if status code is not 401', async () => {
-    jest.spyOn(axios, 'get').mockResolvedValueOnce({
+    jest.spyOn(axios, 'request').mockResolvedValueOnce({
       status: 402
     })
     const { sut } = makeSut()

--- a/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.spec.ts
@@ -243,4 +243,12 @@ describe('UmaAuthenticator', () => {
       validPostResponse.data.access_token
     )
   })
+  it('should call request with GET method', async () => {
+    const { sut } = makeSut()
+    const requestSpy = jest.spyOn(axios, 'request')
+    await sut.authenticate('valid endpoint')
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
 })

--- a/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.spec.ts
@@ -140,7 +140,7 @@ describe('UmaAuthenticator', () => {
       .spyOn(axios, 'request')
       .mockResolvedValueOnce(valid401Response)
     const { sut } = makeSut()
-    await sut.authenticate('valid endpoint')
+    await sut.authenticate('valid endpoint', 'GET')
     expect(requestSpy).toHaveBeenCalledWith(
       expect.objectContaining({ url: 'valid endpoint' })
     )
@@ -150,12 +150,12 @@ describe('UmaAuthenticator', () => {
       status: 402
     })
     const { sut } = makeSut()
-    await expect(sut.authenticate('valid endpoint')).rejects.toThrow()
+    await expect(sut.authenticate('valid endpoint', 'GET')).rejects.toThrow()
   })
   it('should call umaHeaderParser with wwwwAuthenticate value', async () => {
     const { sut, umaHeaderParser } = makeSut()
     const parserSpy = jest.spyOn(umaHeaderParser, 'parse')
-    await sut.authenticate('valid endpoint')
+    await sut.authenticate('valid endpoint', 'GET')
     expect(parserSpy).toHaveBeenCalledWith(
       'UMA realm="Authorization required", host_id=apitest.techno24x7.com, as_uri=https://apitest.techno24x7.com/.well-known/uma2-configuration, ticket=e72ae32f-ad6d-458d-bf18-d34cd5081fb3'
     )
@@ -165,12 +165,12 @@ describe('UmaAuthenticator', () => {
     jest.spyOn(umaHeaderParser, 'parse').mockImplementationOnce(() => {
       throw new UmaHeaderError('any error')
     })
-    await expect(sut.authenticate('valid endpoint')).rejects.toThrow()
+    await expect(sut.authenticate('valid endpoint', 'GET')).rejects.toThrow()
   })
   it('should call readFileSync with pvkPath', async () => {
     const { sut, oxTrustApiSettings } = makeSut()
     const readFileSyncSpy = jest.spyOn(fs, 'readFileSync')
-    await sut.authenticate('valid endpoint')
+    await sut.authenticate('valid endpoint', 'GET')
     expect(readFileSyncSpy).toHaveBeenCalled()
     expect(readFileSyncSpy).toHaveBeenCalledWith(
       oxTrustApiSettings.pvkPath,
@@ -197,7 +197,7 @@ describe('UmaAuthenticator', () => {
     }
     const expectedSecret = 'pvk loaded from file'
 
-    await sut.authenticate('valid endpoint')
+    await sut.authenticate('valid endpoint', 'GET')
     expect(signSpy).toHaveBeenCalledWith(
       expectedHeader,
       expectedPayload,
@@ -207,7 +207,7 @@ describe('UmaAuthenticator', () => {
   it('should call TokenRequestFactory with correct params', async () => {
     const { sut, tokenRequestFactory } = makeSut()
     const makeSpy = jest.spyOn(tokenRequestFactory, 'make')
-    await sut.authenticate('valid endpoint')
+    await sut.authenticate('valid endpoint', 'GET')
     expect(makeSpy).toHaveBeenCalledWith(
       'valid parsed ticket # stub',
       'valid client id',
@@ -220,7 +220,7 @@ describe('UmaAuthenticator', () => {
     const expectedUrl = oxTrustApiSettings.tokenUrl
     const expectedBody = stringify(requestBodyStub)
     const postSpy = jest.spyOn(axios, 'post')
-    await sut.authenticate('valid endpoint')
+    await sut.authenticate('valid endpoint', 'GET')
     expect(postSpy.mock.calls[0][2]).toEqual({
       httpsAgent: expect.any(Agent),
       validateStatus: expect.any(Function)
@@ -234,21 +234,29 @@ describe('UmaAuthenticator', () => {
   it('should call https Agent once with correct params', async () => {
     const agentSpy = jest.spyOn(https, 'Agent')
     const { sut } = makeSut()
-    await sut.authenticate('valid endpoint')
+    await sut.authenticate('valid endpoint', 'GET')
     expect(agentSpy).toHaveBeenCalledWith({ rejectUnauthorized: false })
   })
   it('should return bearer token', async () => {
     const { sut } = makeSut()
-    expect(await sut.authenticate('valid endpoint')).toEqual(
+    expect(await sut.authenticate('valid endpoint', 'GET')).toEqual(
       validPostResponse.data.access_token
     )
   })
   it('should call request with GET method', async () => {
     const { sut } = makeSut()
     const requestSpy = jest.spyOn(axios, 'request')
-    await sut.authenticate('valid endpoint')
+    await sut.authenticate('valid endpoint', 'GET')
     expect(requestSpy).toHaveBeenCalledWith(
       expect.objectContaining({ method: 'GET' })
+    )
+  })
+  it('should call request with POST method', async () => {
+    const { sut } = makeSut()
+    const requestSpy = jest.spyOn(axios, 'request')
+    await sut.authenticate('valid endpoint', 'POST')
+    expect(requestSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'POST' })
     )
   })
 })

--- a/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.test.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.test.ts
@@ -55,7 +55,7 @@ describe('UmaAuthenticator', () => {
     mockUnauthorizedEndpoint()
     mockTokenEndpoint()
     await expect(
-      sut.authenticate('https://mock.com' + unauthorizedEndpoint)
+      sut.authenticate('https://mock.com' + unauthorizedEndpoint, 'GET')
     ).resolves.not.toThrow()
   })
 })

--- a/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto'
 import { readFileSync } from 'fs'
 import { Agent } from 'https'
 import { stringify } from 'querystring'
+import { IHttpMethod } from '../protocols/IHttpMethod'
 import { IJwtHeader } from '../protocols/IJwtHeader'
 import { IJwtPayload } from '../protocols/IJwtPayload'
 import { IJwtSigner } from '../protocols/IJwtSigner'
@@ -28,15 +29,16 @@ export class UmaAuthenticator implements IUmaAuthenticator {
     private readonly requestFactory: ITokenRequestFactory
   ) {}
 
-  async authenticate(endpoint: string): Promise<string> {
+  async authenticate(endpoint: string, method: IHttpMethod): Promise<string> {
     // const endpointResponse = await axios.get(endpoint, this.AXIOS_CONFIG)
     const endpointResponse = await axios.request({
       url: endpoint,
       ...this.AXIOS_CONFIG,
-      method: 'GET'
+      method
     })
     if (endpointResponse.status !== 401) {
-      throw new Error()
+      console.log(`endpointResponse.status = ${endpointResponse.status}`)
+      throw new Error(endpointResponse.data)
     } else {
       const wwwAuthenticate = this.umaHeaderParser.parse(
         endpointResponse.headers['www-authenticate']

--- a/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/helpers/UmaAuthenticator.ts
@@ -29,7 +29,12 @@ export class UmaAuthenticator implements IUmaAuthenticator {
   ) {}
 
   async authenticate(endpoint: string): Promise<string> {
-    const endpointResponse = await axios.get(endpoint, this.AXIOS_CONFIG)
+    // const endpointResponse = await axios.get(endpoint, this.AXIOS_CONFIG)
+    const endpointResponse = await axios.request({
+      url: endpoint,
+      ...this.AXIOS_CONFIG,
+      method: 'GET'
+    })
     if (endpointResponse.status !== 401) {
       throw new Error()
     } else {

--- a/packages/sp-proxy/src/interface-adapters/data/mocks/mockUmaEndpoint.mock.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/mocks/mockUmaEndpoint.mock.ts
@@ -7,7 +7,7 @@ import { mockTokenEndpoint } from './mockTokenEndpoint.mock'
  * @param endpoint endpoint without first slash
  * @param responseData
  */
-export const mockUmaEndpoint = (
+export const mockGetUmaEndpoint = (
   endpoint: string,
   responseData: object
 ): void => {
@@ -17,9 +17,29 @@ export const mockUmaEndpoint = (
       'UMA realm="Authorization required", host_id=apitest.techno24x7.com, as_uri=https://apitest.techno24x7.com/.well-known/uma2-configuration, ticket=e72ae32f-ad6d-458d-bf18-d34cd5081fb3'
   }
   const mockedBasePath = `https://${config.oxTrustApi.host}/${config.oxTrustApi.completePath}`
-
   nock(mockedBasePath)
     .get(`/${endpoint}`)
     .reply(401, {}, unauthorizedResponseHeaders)
   nock(mockedBasePath).get(`/${endpoint}`).reply(200, responseData)
+}
+
+/**
+ *
+ * @param endpoint endpoint without first slash
+ * @param responseData
+ */
+export const mockPostUmaEndpoint = (
+  endpoint: string,
+  responseData: object
+): void => {
+  mockTokenEndpoint()
+  const unauthorizedResponseHeaders = {
+    'WWW-Authenticate':
+      'UMA realm="Authorization required", host_id=apitest.techno24x7.com, as_uri=https://apitest.techno24x7.com/.well-known/uma2-configuration, ticket=e72ae32f-ad6d-458d-bf18-d34cd5081fb3'
+  }
+  const mockedBasePath = `https://${config.oxTrustApi.host}/${config.oxTrustApi.completePath}`
+  nock(mockedBasePath)
+    .post(`/${endpoint}`)
+    .reply(401, {}, unauthorizedResponseHeaders)
+  nock(mockedBasePath).post(`/${endpoint}`).reply(201, responseData)
 }

--- a/packages/sp-proxy/src/interface-adapters/data/protocols/IHttpMethod.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/protocols/IHttpMethod.ts
@@ -1,0 +1,1 @@
+export type IHttpMethod = 'POST' | 'GET'

--- a/packages/sp-proxy/src/interface-adapters/data/protocols/IUmaAuthenticator.ts
+++ b/packages/sp-proxy/src/interface-adapters/data/protocols/IUmaAuthenticator.ts
@@ -1,3 +1,5 @@
+import { IHttpMethod } from './IHttpMethod'
+
 export interface IUmaAuthenticator {
-  authenticate: (endpoint: string) => Promise<string>
+  authenticate: (endpoint: string, method: IHttpMethod) => Promise<string>
 }


### PR DESCRIPTION
Close #121 

- Allowing self signed certificate on oxtrust api requests

- Use same method and endpoint that bearer token gonna be used to request ticket # , that's the only way to have needed permissions   