### PR TITLE
feat(server): turn ssl into optional

### DIFF
--- a/packages/sp-proxy/src/frameworks-drivers/main/config/env.ts
+++ b/packages/sp-proxy/src/frameworks-drivers/main/config/env.ts
@@ -1,12 +1,13 @@
 export default {
-  adminUser: process.env.ADMIN_USER ?? 'admin',
-  adminPassword: process.env.ADMIN_PWD ?? 'admin',
-  logLevel: process.env.LOG_LEVEL ?? 'debug',
-  port: process.env.PORT ?? '5000',
+  adminUser: process.env.INBOUND_SAML_ADMIN_USER ?? 'admin',
+  adminPassword: process.env.INBOUND_SAML_ADMIN_PWD ?? 'admin',
+  logLevel: process.env.INBOUND_SAML_LOG_LEVEL ?? 'debug',
+  port: process.env.INBOUND_SAML_PORT ?? '5000',
+  useTls: process.env.INBOUND_SAML_USE_TLS ?? false,
   tlsCertPath:
-    process.env.TLS_CERT_PATH ??
+    process.env.INBOUND_SAML_TLS_CERT_PATH ??
     `${process.cwd()}/packages/sp-proxy/src/frameworks-drivers/main/cert/cert.pem`,
   tlsKeyPath:
-    process.env.TLS_KEY_PATH ??
+    process.env.INBOUND_SAML_TLS_KEY_PATH ??
     `${process.cwd()}/packages/sp-proxy/src/frameworks-drivers/main/cert/key.pem`
 }

--- a/packages/sp-proxy/src/frameworks-drivers/main/config/env.ts
+++ b/packages/sp-proxy/src/frameworks-drivers/main/config/env.ts
@@ -3,7 +3,7 @@ export default {
   adminPassword: process.env.INBOUND_SAML_ADMIN_PWD ?? 'admin',
   logLevel: process.env.INBOUND_SAML_LOG_LEVEL ?? 'debug',
   port: process.env.INBOUND_SAML_PORT ?? '5000',
-  useTls: process.env.INBOUND_SAML_USE_TLS ?? false,
+  useTls: process.env.INBOUND_SAML_USE_TLS ?? true,
   tlsCertPath:
     process.env.INBOUND_SAML_TLS_CERT_PATH ??
     `${process.cwd()}/packages/sp-proxy/src/frameworks-drivers/main/cert/cert.pem`,

--- a/packages/sp-proxy/src/frameworks-drivers/main/server.ts
+++ b/packages/sp-proxy/src/frameworks-drivers/main/server.ts
@@ -1,16 +1,22 @@
+import cfg from '@sp-proxy/frameworks-drivers/main/config/env'
 import routes from '@sp-proxy/frameworks-drivers/main/routes'
 import express from 'express'
 import { readFileSync } from 'fs'
+import http from 'http'
 import https from 'https'
-import cfg from '@sp-proxy/frameworks-drivers/main/config/env'
 
 const app = express()
 
 app.use(routes)
 app.use(express.urlencoded({ extended: false }))
-const cert = readFileSync(cfg.tlsCertPath).toString()
-const key = readFileSync(cfg.tlsKeyPath).toString()
-const server = https.createServer({ key: key, cert: cert }, app)
-server.listen(cfg.port, () => console.log('server started'))
+if (cfg.useTls === false) {
+  const server = http.createServer(app)
+  server.listen(cfg.port, () => console.log('server started'))
+} else {
+  const cert = readFileSync(cfg.tlsCertPath).toString()
+  const key = readFileSync(cfg.tlsKeyPath).toString()
+  const server = https.createServer({ key: key, cert: cert }, app)
+  server.listen(cfg.port, () => console.log('server started'))
+}
 
 export default app


### PR DESCRIPTION
As non-ssl may be required to internal communication, proxy server's SSL is now **optional**.