### PR TITLE
fix(CreateRemoteIdp): throws if no host param

### DIFF
--- a/packages/sp-proxy/src/interface-adapters/delivery/validators/CreateRemoteIdpValidator.spec.ts
+++ b/packages/sp-proxy/src/interface-adapters/delivery/validators/CreateRemoteIdpValidator.spec.ts
@@ -43,10 +43,24 @@ describe('CreateRemoteIdpValidator', () => {
     const validRequest = {
       body: {
         name: 'valid name',
+        host: 'valid host',
         signingCertificates: ['valid cert 1', 'valid cert 2'],
         singleSignOnService: ['valid ssoService']
       }
     }
     expect(await sut.isValid(validRequest as any)).toBeTruthy()
+  })
+  it('should throw InvalidRequestError if no host', async () => {
+    const sut = new CreateRemoteIdpValidator()
+    const invalidRequest = {
+      body: {
+        name: 'valid name',
+        signingCertificates: ['valid cert 1', 'valid cert 2'],
+        singleSignOnService: ['valid ssoService']
+      }
+    }
+    await expect(sut.isValid(invalidRequest as any)).rejects.toThrow(
+      new InvalidRequestError('Missing param: host.')
+    )
   })
 })

--- a/packages/sp-proxy/src/interface-adapters/delivery/validators/CreateRemoteIdpValidator.ts
+++ b/packages/sp-proxy/src/interface-adapters/delivery/validators/CreateRemoteIdpValidator.ts
@@ -14,6 +14,8 @@ export class CreateRemoteIdpValidator implements IValidator {
       throw new InvalidRequestError('Missing param: singleSignOnService.')
     } else if (!('signingCertificates' in request.body)) {
       throw new InvalidRequestError('Missing param: signingCertificates.')
+    } else if (!('host' in request.body)) {
+      throw new InvalidRequestError('Missing param: host.')
     }
     return true
   }


### PR DESCRIPTION
Ref #132 

Validation was checking all fields but not `host`.
When requesting controller without `host` param, it throws.