### PR TITLE
feat(serverConfig): parse int and bool from env

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:all": "yarn test:unit && yarn test:integration",
     "test:integration:docker": "docker-compose -f docker-compose-test.yml up -d && yarn test:integration && docker-compose -f docker-compose-test.yml down",
     "test:coverage": "jest --ci --coverage",
-    "test:behaviour": "NODE_ENV=test cucumber-js packages/get-saml-metadata packages/sp-proxy -p default --exit",
+    "test:behaviour": "NODE_ENV=test INBOUND_SAML_USE_TLS=true cucumber-js packages/get-saml-metadata packages/sp-proxy -p default --exit",
     "test:staged": "yarn test:all --no-cache --findRelatedTests",
     "prepare": "husky install",
     "build": "tsc && tsc-alias",

--- a/packages/sp-proxy/src/frameworks-drivers/main/config/env.ts
+++ b/packages/sp-proxy/src/frameworks-drivers/main/config/env.ts
@@ -1,9 +1,17 @@
+import { StringParser } from '../helpers/StringParser'
+import { BooleanStringType } from '../protocols/BooleanStringType'
+
+const stringParser = new StringParser()
+
+const portString = process.env.INBOUND_SAML_PORT ?? '5000'
+const useTlsString = process.env.INBOUND_SAML_USE_TLS ?? 'false'
+
 export default {
   adminUser: process.env.INBOUND_SAML_ADMIN_USER ?? 'admin',
   adminPassword: process.env.INBOUND_SAML_ADMIN_PWD ?? 'admin',
   logLevel: process.env.INBOUND_SAML_LOG_LEVEL ?? 'debug',
-  port: process.env.INBOUND_SAML_PORT ?? '5000',
-  useTls: process.env.INBOUND_SAML_USE_TLS ?? true,
+  port: stringParser.stringToInt(portString),
+  useTls: stringParser.stringToBool(useTlsString as BooleanStringType),
   tlsCertPath:
     process.env.INBOUND_SAML_TLS_CERT_PATH ??
     `${process.cwd()}/packages/sp-proxy/src/frameworks-drivers/main/cert/cert.pem`,


### PR DESCRIPTION
Parse int and boolean values from environment variables when loading configuration for production env.